### PR TITLE
Add PATH expansion to run cron job

### DIFF
--- a/deploy_ntp_query.yml
+++ b/deploy_ntp_query.yml
@@ -40,5 +40,4 @@
     - name: Configure cron task
       ansible.builtin.cron:
         name: "Run ntpqt"
-        job: "{{ ansible_python.executable }} /opt/ntp_query_tool/query_ntp_status.py >> /var/log/ntpqt/ntpqt.log 2>&1"
-
+        job: "export PATH=$PATH:/usr/bin:/usr/sbin/; {{ ansible_python.executable }} /opt/ntp_query_tool/query_ntp_status.py >> /var/log/ntpqt/ntpqt.log 2>&1"


### PR DESCRIPTION
query_ntp_status.py forks out `pidof`, but on rhel7/8 that binary is not located in the default PATH for cron jobs. This change sets the path required for the script to sucessfully run under cron.
